### PR TITLE
Added session cache limiter to false

### DIFF
--- a/RKA/SessionMiddleware.php
+++ b/RKA/SessionMiddleware.php
@@ -53,6 +53,7 @@ final class SessionMiddleware extends Middleware
 
         session_set_cookie_params($lifetime, $path, $domain, $secure, $httponly);
         session_name($options['name']);
+        session_cache_limiter(false); //http://docs.slimframework.com/#Sessions
         session_start();
     }
 }


### PR DESCRIPTION
http://docs.slimframework.com/#Sessions

You should also disable PHP’s session cache limiter so that PHP does not send conflicting cache expiration headers with the HTTP response.